### PR TITLE
Support rotate of whole Blueprint

### DIFF
--- a/packages/editor/src/Editor.ts
+++ b/packages/editor/src/Editor.ts
@@ -162,24 +162,26 @@ export class Editor {
 
         registerAction('focus', 'f').bind({ press: () => G.BPC.centerViewport() })
 
-        registerAction('rotate', 'r').bind({
-            press: () => {
-                if (G.BPC.mode === EditorMode.EDIT) {
-                    G.BPC.hoverContainer.entity.rotate(false, true)
-                } else if (G.BPC.mode === EditorMode.PAINT) {
-                    G.BPC.paintContainer.rotate()
+        function doRotate(ccw: boolean): void  {
+            if (G.BPC.mode === EditorMode.EDIT) {
+                G.BPC.hoverContainer.entity.rotate(false, true)
+            } else if (G.BPC.mode === EditorMode.PAINT) {
+                const copies = G.BPC.paintContainer.rotatedEntities(ccw)
+                if (copies === undefined) {
+                    G.BPC.paintContainer.rotate(ccw)
+                } else {
+                    G.BPC.paintContainer.destroy()
+                    G.BPC.spawnPaintContainer(copies, 0)
                 }
-            },
+            }
+        }
+
+        registerAction('rotate', 'r').bind({
+            press: () => doRotate(false)
         })
 
         registerAction('reverseRotate', 'shift+r').bind({
-            press: () => {
-                if (G.BPC.mode === EditorMode.EDIT) {
-                    G.BPC.hoverContainer.entity.rotate(true, true)
-                } else if (G.BPC.mode === EditorMode.PAINT) {
-                    G.BPC.paintContainer.rotate(true)
-                }
-            },
+            press: () => doRotate(true)
         })
 
         registerAction('pipette', 'q').bind({

--- a/packages/editor/src/containers/PaintBlueprintContainer.ts
+++ b/packages/editor/src/containers/PaintBlueprintContainer.ts
@@ -85,11 +85,18 @@ export class PaintBlueprintContainer extends PaintContainer {
     }
 
     public rotate(): void {
-        if (!this.visible) return
-
-        // TODO: implement
         return undefined
     }
+
+    public rotatedEntities(ccw?: boolean): Entity[] {
+        if (!this.visible) return undefined
+        const result = []
+        for (const [e] of this.entities) {
+            result.push(e.getRotatedCopy(ccw))
+        }
+        return result
+    }
+
 
     public moveAtCursor(): void {
         if (!this.visible) return

--- a/packages/editor/src/containers/PaintContainer.ts
+++ b/packages/editor/src/containers/PaintContainer.ts
@@ -1,5 +1,6 @@
 import * as PIXI from 'pixi.js'
 import G from '../common/globals'
+import { Entity } from '../core/Entity'
 import F from '../UI/controls/functions'
 import { BlueprintContainer } from './BlueprintContainer'
 
@@ -90,8 +91,11 @@ export abstract class PaintContainer extends PIXI.Container {
     // override
     public abstract getItemName(): string
 
-    // override
+    // override 
     public abstract rotate(ccw?: boolean): void
+
+    // override 
+    public abstract rotatedEntities(ccw?: boolean): Entity[]
 
     // override
     protected abstract redraw(): void

--- a/packages/editor/src/containers/PaintEntityContainer.ts
+++ b/packages/editor/src/containers/PaintEntityContainer.ts
@@ -130,6 +130,10 @@ export class PaintEntityContainer extends PaintContainer {
         this.moveAtCursor()
     }
 
+    public rotatedEntities(): Entity[] {
+        return undefined
+    }
+
     protected redraw(): void {
         this.removeChildren()
         const sprites = EntitySprite.getParts({

--- a/packages/editor/src/containers/PaintTileContainer.ts
+++ b/packages/editor/src/containers/PaintTileContainer.ts
@@ -3,6 +3,7 @@ import { Tile } from '../core/Tile'
 import { TileContainer } from './TileContainer'
 import { PaintContainer } from './PaintContainer'
 import { BlueprintContainer } from './BlueprintContainer'
+import { Entity } from '../core/Entity'
 
 export class PaintTileContainer extends PaintContainer {
     private static size = 2
@@ -65,6 +66,10 @@ export class PaintTileContainer extends PaintContainer {
             this.name = nD
             this.redraw()
         }
+    }
+
+    public rotatedEntities(): Entity[] {
+        return undefined
     }
 
     protected redraw(): void {

--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -526,17 +526,27 @@ export class Entity extends EventEmitter {
         )
     }
 
-    public rotate(ccw = false, rotateOpposingUB = false): void {
-        if (!this.canBeRotated) return
+    public getRotatedCopy(ccw = false): Entity {
+        const position = ccw
+            ? {x: this.m_rawEntity.position.y, y: -this.m_rawEntity.position.x}
+            : {x: -this.m_rawEntity.position.y, y: this.m_rawEntity.position.x}
+        const direction = this.rotateDir(ccw)
+        return new Entity({...this.m_rawEntity, position, direction}, this.m_BP);
+    }
 
+    private rotateDir(ccw: boolean): number {
+        if (!this.canBeRotated) return this.direction
         const pr = this.entityData.possible_rotations
-        const newDir =
-            pr[
+        return pr[
                 (pr.indexOf(this.direction) +
                     (this.size.x !== this.size.y || this.type === 'underground_belt' ? 2 : 1) *
                         (ccw ? 3 : 1)) %
                     pr.length
             ]
+    }
+
+    public rotate(ccw = false, rotateOpposingUB = false): void {
+        const newDir = this.rotateDir(ccw)
 
         if (newDir === this.direction) return
 


### PR DESCRIPTION
Addresses the first bullet of #9. If you like the approach, I will implement flipping. 

Note that I might have taken a different approach from what you had originally intended. It seems like you had wanted to rotate the blueprint "in place" in the PaintBlueprintContainer. I imagine this was either through some property like direction, or though updating the entities. 

As you can see, the approach I took as to create a new, modified blueprint by rotating the entities. 

The problem I ran into for these approaches is that lots of other places seem to assume the position will never change, (e.g., visualization area). So it seemed like major surgery to allow this kind of modification.  

From my eyes, it's the simplest way I could come up with to implement it, and the nice thing is that it's unlikely I've broken anything (other than maybe some rotate action that I didn't see) because the changes are mostly additive.