### PR TITLE
fix duplicate wires on same entity

### DIFF
--- a/packages/editor/src/core/WireConnections.ts
+++ b/packages/editor/src/core/WireConnections.ts
@@ -27,7 +27,7 @@ export class WireConnections extends EventEmitter {
     }
 
     private static hash(conn: IConnection): string {
-        const cps = conn.cps.sort((cp1,cp2) => cp1.entityNumber - cp2.entityNumber)
+        const cps = conn.cps.sort((cp1,cp2) => cp1.entityNumber-cp2.entityNumber || cp1.entitySide-cp2.entitySide)
         const [firstE, secondE] = cps.map(cp => cp.entityNumber)
         const [firstS, secondS] = cps.map(cp => cp.entitySide)
         return `${conn.color}-${firstE}-${secondE}-${firstS}-${secondS}`


### PR DESCRIPTION
Bug: connecting the input to the output of a decider/arithmetic combinator produced a different wire than connecting the output to the input. This is a problem when trying to remove existing wires.
![image](https://github.com/teoxoy/factorio-blueprint-editor/assets/14861519/be92237d-583f-4c4e-a33b-f5ff284e9791)

Fix: make the hash the same, independently of connection point ordering.