### PR TITLE
Update to Factorio 1.1.100

### DIFF
--- a/packages/exporter/src/export-data/control.lua
+++ b/packages/exporter/src/export-data/control.lua
@@ -1,9 +1,9 @@
 script.on_init(function()
     -- EXTRACT SERIALIZED DATA
-    local l = tonumber(game.entity_prototypes["DATA"].localised_name)
+    local l = tonumber(game.entity_prototypes["FBE-DATA-COUNT"].localised_name)
     local serialized = ""
     for i = 1, l, 1 do
-        serialized = serialized .. game.entity_prototypes[tostring(i)].localised_name
+        serialized = serialized .. game.entity_prototypes["FBE-DATA-" .. tostring(i)].localised_name
     end
     local data = load(serialized)()
     game.write_file('data.json', game.table_to_json(data), false, 0)

--- a/packages/exporter/src/export-data/data-final-fixes.lua
+++ b/packages/exporter/src/export-data/data-final-fixes.lua
@@ -372,48 +372,48 @@ do
 
                 -- add possible_rotations
                 if list_includes({
-                    'pipe-to-ground',
-                    'train-stop',
-                    'arithmetic-combinator',
-                    'decider-combinator',
-                    'constant-combinator',
-                    'artillery-turret',
-                    'flamethrower-turret',
-                    'offshore-pump',
-                    'pump'
-                }, entity.name) or list_includes({
-                    'underground-belt',
-                    'transport-belt',
-                    'splitter',
-                    'inserter',
-                    'boiler',
-                    'mining-drill',
-                    'assembling-machine',
-                    'loader'
-                }, entity.type) then
+                        'pipe-to-ground',
+                        'train-stop',
+                        'arithmetic-combinator',
+                        'decider-combinator',
+                        'constant-combinator',
+                        'artillery-turret',
+                        'flamethrower-turret',
+                        'offshore-pump',
+                        'pump'
+                    }, entity.name) or list_includes({
+                        'underground-belt',
+                        'transport-belt',
+                        'splitter',
+                        'inserter',
+                        'boiler',
+                        'mining-drill',
+                        'assembling-machine',
+                        'loader'
+                    }, entity.type) then
 
                     entity.possible_rotations = { 0, 2, 4, 6 }
 
                 elseif list_includes({
-                    'storage-tank',
-                    'gate',
-                }, entity.name) or list_includes({
-                    'generator'
-                }, entity.type) then
+                        'storage-tank',
+                        'gate',
+                    }, entity.name) or list_includes({
+                        'generator'
+                    }, entity.type) then
 
                     entity.possible_rotations = { 0, 2 }
 
                 elseif list_includes({
-                    'curved-rail',
-                    'rail-signal',
-                    'rail-chain-signal'
-                }, entity.name) then
+                        'curved-rail',
+                        'rail-signal',
+                        'rail-chain-signal'
+                    }, entity.name) then
 
                     entity.possible_rotations = { 0, 1, 2, 3, 4, 5, 6, 7 }
 
                 elseif list_includes({
-                    'straight-rail'
-                }, entity.name) then
+                        'straight-rail'
+                    }, entity.name) then
 
                     entity.possible_rotations = { 0, 1, 2, 3, 5, 7 }
                 end
@@ -616,9 +616,9 @@ do
             icon = "-",
             icon_size = 1,
             picture = {
-            filename = "-",
-            width = 1,
-            height = 1
+                filename = "-",
+                width = 1,
+                height = 1
             },
             localised_name = value
         }})
@@ -628,8 +628,8 @@ do
     local total_parts = 0
     for i = 1, l, 200 do
         total_parts = total_parts + 1
-        embed_data(total_parts, string.sub(serialized, i, i + 199))
+        embed_data('FBE-DATA-' .. tostring(total_parts), string.sub(serialized, i, i + 199))
     end
 
-    embed_data('DATA', total_parts)
+    embed_data('FBE-DATA-COUNT', total_parts)
 end

--- a/packages/exporter/src/export-data/data-final-fixes.lua
+++ b/packages/exporter/src/export-data/data-final-fixes.lua
@@ -372,48 +372,48 @@ do
 
                 -- add possible_rotations
                 if list_includes({
-                        'pipe-to-ground',
-                        'train-stop',
-                        'arithmetic-combinator',
-                        'decider-combinator',
-                        'constant-combinator',
-                        'artillery-turret',
-                        'flamethrower-turret',
-                        'offshore-pump',
-                        'pump'
-                    }, entity.name) or list_includes({
-                        'underground-belt',
-                        'transport-belt',
-                        'splitter',
-                        'inserter',
-                        'boiler',
-                        'mining-drill',
-                        'assembling-machine',
-                        'loader'
-                    }, entity.type) then
+                    'pipe-to-ground',
+                    'train-stop',
+                    'arithmetic-combinator',
+                    'decider-combinator',
+                    'constant-combinator',
+                    'artillery-turret',
+                    'flamethrower-turret',
+                    'offshore-pump',
+                    'pump'
+                }, entity.name) or list_includes({
+                    'underground-belt',
+                    'transport-belt',
+                    'splitter',
+                    'inserter',
+                    'boiler',
+                    'mining-drill',
+                    'assembling-machine',
+                    'loader'
+                }, entity.type) then
 
                     entity.possible_rotations = { 0, 2, 4, 6 }
 
                 elseif list_includes({
-                        'storage-tank',
-                        'gate',
-                    }, entity.name) or list_includes({
-                        'generator'
-                    }, entity.type) then
+                    'storage-tank',
+                    'gate',
+                }, entity.name) or list_includes({
+                    'generator'
+                }, entity.type) then
 
                     entity.possible_rotations = { 0, 2 }
 
                 elseif list_includes({
-                        'curved-rail',
-                        'rail-signal',
-                        'rail-chain-signal'
-                    }, entity.name) then
+                    'curved-rail',
+                    'rail-signal',
+                    'rail-chain-signal'
+                }, entity.name) then
 
                     entity.possible_rotations = { 0, 1, 2, 3, 4, 5, 6, 7 }
 
                 elseif list_includes({
-                        'straight-rail'
-                    }, entity.name) then
+                    'straight-rail'
+                }, entity.name) then
 
                     entity.possible_rotations = { 0, 1, 2, 3, 5, 7 }
                 end
@@ -616,9 +616,9 @@ do
             icon = "-",
             icon_size = 1,
             picture = {
-                filename = "-",
-                width = 1,
-                height = 1
+            filename = "-",
+            width = 1,
+            height = 1
             },
             localised_name = value
         }})

--- a/packages/exporter/src/main.rs
+++ b/packages/exporter/src/main.rs
@@ -6,7 +6,7 @@ mod setup;
 #[macro_use]
 extern crate lazy_static;
 
-static FACTORIO_VERSION: &str = "1.1.41";
+static FACTORIO_VERSION: &str = "1.1.100";
 
 lazy_static! {
     static ref DATA_DIR: PathBuf = PathBuf::from("./data");


### PR DESCRIPTION
Version 1.1.41 is no longer available. Moved to 1.1.100.

`yarn run start:exporter` now succeeds. Without the `FBE-DATA-` changes it fails with the error shared by Mike on Discord:
https://discord.com/channels/540738973413408809/543167234470838272/1180566492803256331
```
  1.393 Loading mod export-data 0.0.0 (data-final-fixes.lua)
   5.515 Error Util.cpp:86: Failed to load mod "export-data": bad argument #7 of 8 to '?' (string expected, got number)
stack traceback:
    [C]: in ?
```

I did a smoke test with `yarn run start:website`. All of the basis behavior appears to work just fine.

There is a huge diff of `.basis` files + `data.json` + `metadata.yaml`. I wasn't sure if you wanted these included in the diff. I'm happy to commit them if it's intended.
![image](https://github.com/teoxoy/factorio-blueprint-editor/assets/94054/0fb10e4e-f5df-4c31-b8f3-b07a09ffdf0e)

```bash
joel@Nox:~/factorio-blueprint-editor$ git status | grep "new file:" | wc -l
100
joel@Nox:~/factorio-blueprint-editor$ git status | grep "deleted:" | wc -l
1
joel@Nox:~/factorio-blueprint-editor$ git status | grep "modified:" | wc -l
2305
```

You can see the commit here: https://github.com/joelverhagen/factorio-blueprint-editor/commit/c439499aaddfd0a6502dfbdbbbaf761b13fcb878 (not in the PR currently)

